### PR TITLE
Added "scheme-mode" support with "geiser".

### DIFF
--- a/corgi-stateline/corgi-stateline.el
+++ b/corgi-stateline/corgi-stateline.el
@@ -11,7 +11,7 @@
   :type 'color
   :group 'corgi)
 
-(defcustom corgi-stateline-normal-bg "orange"
+(defcustom corgi-stateline-normal-bg "gray"
   "Background color of the modeline in evil normal state"
   :type 'color
   :group 'corgi)

--- a/corkey/corgi-keys.el
+++ b/corkey/corgi-keys.el
@@ -44,6 +44,7 @@
   ("b" "Buffer commands"
    ("b" "Switch buffer" ivy-switch-buffer)
    ("d" "Kill buffer" kill-this-buffer)
+   ("k" "Pick & kill" kill-buffer)
    ("l" "List buffers" list-buffers)
    ("r" "Rename buffer" rename-buffer)
    ("w" "Toggle read-only" read-only-mode))
@@ -65,6 +66,7 @@
   ("p" "Project"
    ("f" "Find file" :project/open-file)
    ("p" "Switch project" :project/switch)
+   ("k" "Kill buffers" :project/kill)
    ("s" "Search in project" :project/incremental-search))
 
   ("g" "Git"

--- a/corkey/corgi-signals.el
+++ b/corkey/corgi-signals.el
@@ -17,6 +17,7 @@
 
                       :project/open-file projectile-find-file
                       :project/switch projectile-switch-project
+                      :project/kill projectile-kill-buffers
                       :project/incremental-search counsel-git-grep
 
                       :jump/identifier counsel-imenu
@@ -46,6 +47,10 @@
                    :refactor/thread-last corgi/elisp-thread-last-all))
 
  (inferior-emacs-lisp-mode ( :repl/toggle corgi/switch-to-last-elisp-buffer))
+
+ (scheme-mode ( :eval/last-sexp geiser-eval-last-sexp
+                :eval/buffer geiser-eval-buffer
+                :eval/region geiser-eval-region))
 
  (clojure-mode (
                 :repl/connect cider-connect


### PR DESCRIPTION
<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
Hi, thanks for corgi. I really enjoy using it. 

I've added some extra keys and signals and suggest changing normal mode stateline color from 'orange' to 'gray' for people who have trouble telling the difference between orange and green (like me). 

Changes include:
1. signals: `scheme-mode` to support global eval key sequences for scheme with "geiser"
2. keys: 
    i. 'Spc b k' to `kill-buffer` list buffers and select to kill.
    ii. 'Spc p k' to `projectile-kill-buffers` kill all buffers of current project (quit project).
3. stateline: changed `corgi-stateline-normal-bg` from 'orange' -> 'gray'