### PR TITLE
Improve mac defaults

### DIFF
--- a/corgi-defaults/corgi-defaults.el
+++ b/corgi-defaults/corgi-defaults.el
@@ -120,6 +120,12 @@
 (set-fontset-font t 'symbol "Segoe UI Emoji" nil 'append)
 (set-fontset-font t 'symbol "Symbola" nil 'append)
 
+;; Configure mac modifiers to be what you expect, and turn off the bell noise
+(if (equal system-type 'darwin)
+  (setq ring-bell-function 'ignore
+        mac-command-modifier 'control
+        mac-option-modifier 'meta))
+
 (provide 'corgi-defaults)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Not sure if this is worth putting in the changelog - I tried corgi on my mac and was immediately hit with the annoying default emacs bindings for `cmd` and `option`.

I also removed the bell noise for mac users - I'm not sure if this is turned off elsewhere for Linux users, but using evil with the bell is pure torture.