### PR TITLE
Update to use display-line-numbers-mode instead of linum-mode

### DIFF
--- a/corkey/corgi-keys.el
+++ b/corkey/corgi-keys.el
@@ -141,7 +141,7 @@
 
    ("t" "Toggle modes"
     ("a" "Toggle aggressive indent mode" aggressive-indent-mode)
-    ("l" "Toggle line numbers" linum-mode)
+    ("l" "Toggle line numbers" display-line-numbers-mode)
     ("q" "Toggle debug on quit" toggle-debug-on-quit)
     ("e" "Toggle debug on error" toggle-debug-on-error))
 


### PR DESCRIPTION
Very minor change to switch the SPC t l binding from using linum-mode to display-line-numbers-mode. 

Note that as the CHANGELOG is in the corgi repository and there is none in corgi-packages repository, I've not provided a changelog entry as that would just mean a second PR just for the changelog. 