### PR TITLE
Complete refactoring of corgi-stateline

### DIFF
--- a/corgi-stateline/corgi-stateline.el
+++ b/corgi-stateline/corgi-stateline.el
@@ -56,31 +56,65 @@
   :type 'color
   :group 'corgi)
 
+(defvar corgi-stateline-remap-cookie nil
+  "Cookie used to hold reference to face remapping.")
+
+(defun corgi-stateline/map-mode-line-face (fg bg)
+  (when corgi-stateline-remap-cookie
+    (face-remap-remove-relative corgi-stateline-remap-cookie))
+  (setq corgi-stateline-remap-cookie (face-remap-add-relative
+                                      'mode-line :foreground fg :background bg)))
+
 (defun corgi-stateline/enter-normal-state ()
-  (face-remap-add-relative 'mode-line-active  :foreground corgi-stateline-normal-fg)
-  (face-remap-add-relative 'mode-line-active  :background corgi-stateline-normal-bg))
+  (corgi-stateline/map-mode-line-face corgi-stateline-normal-fg
+                                      corgi-stateline-normal-bg))
 
 (defun corgi-stateline/enter-motion-state ()
-  (face-remap-add-relative 'mode-line-active  :foreground corgi-stateline-motion-fg)
-  (face-remap-add-relative 'mode-line-active  :background corgi-stateline-motion-bg))
+  (corgi-stateline/map-mode-line-face corgi-stateline-motion-fg
+                                      corgi-stateline-motion-bg))
 
 (defun corgi-stateline/enter-insert-state ()
-  (face-remap-add-relative 'mode-line-active  :foreground corgi-stateline-insert-fg)
-  (face-remap-add-relative 'mode-line-active  :background corgi-stateline-insert-bg))
+  (corgi-stateline/map-mode-line-face corgi-stateline-insert-fg
+                                      corgi-stateline-insert-bg))
 
 (defun corgi-stateline/enter-visual-state ()
-  (face-remap-add-relative 'mode-line-active  :foreground corgi-stateline-visual-fg)
-  (face-remap-add-relative 'mode-line-active  :background corgi-stateline-visual-bg))
+  (corgi-stateline/map-mode-line-face corgi-stateline-visual-fg
+                                      corgi-stateline-visual-bg))
 
 (defun corgi-stateline/enter-emacs-state ()
-  (face-remap-add-relative 'mode-line-active :foreground corgi-stateline-emacs-fg)
-  (face-remap-add-relative 'mode-line-active :background corgi-stateline-emacs-bg))
+  (corgi-stateline/map-mode-line-face corgi-stateline-emacs-fg
+                                      corgi-stateline-emacs-bg))
 
-(add-hook 'evil-normal-state-entry-hook #'corgi-stateline/enter-normal-state)
-(add-hook 'evil-motion-state-entry-hook #'corgi-stateline/enter-motion-state)
-(add-hook 'evil-insert-state-entry-hook #'corgi-stateline/enter-insert-state)
-(add-hook 'evil-visual-state-entry-hook #'corgi-stateline/enter-visual-state)
-(add-hook 'evil-emacs-state-entry-hook #'corgi-stateline/enter-emacs-state)
+(defun corgi-stateline/turn-on ()
+  (message "corgi-stateline adding hooks")
+  (add-hook 'evil-normal-state-entry-hook #'corgi-stateline/enter-normal-state)
+  (add-hook 'evil-motion-state-entry-hook #'corgi-stateline/enter-motion-state)
+  (add-hook 'evil-insert-state-entry-hook #'corgi-stateline/enter-insert-state)
+  (add-hook 'evil-visual-state-entry-hook #'corgi-stateline/enter-visual-state)
+  (add-hook 'evil-emacs-state-entry-hook #'corgi-stateline/enter-emacs-state))
+
+(defun corgi-stateline/turn-off ()
+  (message "corgi-stateline Removing hooks")
+  (remove-hook 'evil-normal-state-entry-hook #'corgi-stateline/enter-normal-state)
+  (remove-hook 'evil-motion-state-entry-hook #'corgi-stateline/enter-motion-state)
+  (remove-hook 'evil-insert-state-entry-hook #'corgi-stateline/enter-insert-state)
+  (remove-hook 'evil-visual-state-entry-hook #'corgi-stateline/enter-visual-state)
+  (remove-hook 'evil-emacs-state-entry-hook #'corgi-stateline/enter-emacs-state)
+  (when corgi-stateline-remap-cookie
+    (face-remap-remove-relative corgi-stateline-remap-cookie)
+    (setq corgi-steteline-remap-cookie nil)))
+
+(define-minor-mode corgi-stateline-mode
+  "Toggle corgi-stateline-mode.
+
+When enabled, this mode will change the color of the mode line
+based on the current evil editing state."
+  :init-value nil
+  :global t
+  :lighter " StLi"
+  (if (default-value 'corgi-stateline-mode)
+      (corgi-stateline/turn-on)
+    (corgi-stateline/turn-off)))
 
 (provide 'corgi-stateline)
 

--- a/corgi-stateline/corgi-stateline.el
+++ b/corgi-stateline/corgi-stateline.el
@@ -6,16 +6,6 @@
 
 ;;; Code:
 
-(defcustom corgi-stateline-normal-fg "black"
-  "Foreground color of the modeline in evil normal state"
-  :type 'color
-  :group 'corgi)
-
-(defcustom corgi-stateline-normal-bg "gray"
-  "Background color of the modeline in evil normal state"
-  :type 'color
-  :group 'corgi)
-
 (defcustom corgi-stateline-motion-fg "black"
   "Foreground color of the modeline in evil motion state"
   :type 'color
@@ -65,9 +55,13 @@
   (setq corgi-stateline-remap-cookie (face-remap-add-relative
                                       'mode-line :foreground fg :background bg)))
 
+(defun corgi-stateline/unmap-mode-line-face ()
+  (when corgi-stateline-remap-cookie
+    (face-remap-remove-relative corgi-stateline-remap-cookie)
+    (setq corgi-steteline-remap-cookie nil)))
+
 (defun corgi-stateline/enter-normal-state ()
-  (corgi-stateline/map-mode-line-face corgi-stateline-normal-fg
-                                      corgi-stateline-normal-bg))
+  (corgi-stateline/unmap-mode-line-face))
 
 (defun corgi-stateline/enter-motion-state ()
   (corgi-stateline/map-mode-line-face corgi-stateline-motion-fg
@@ -98,9 +92,7 @@
   (remove-hook 'evil-insert-state-entry-hook #'corgi-stateline/enter-insert-state)
   (remove-hook 'evil-visual-state-entry-hook #'corgi-stateline/enter-visual-state)
   (remove-hook 'evil-emacs-state-entry-hook #'corgi-stateline/enter-emacs-state)
-  (when corgi-stateline-remap-cookie
-    (face-remap-remove-relative corgi-stateline-remap-cookie)
-    (setq corgi-steteline-remap-cookie nil)))
+  (corgi-stateline/unmap-mode-line-face))
 
 (define-minor-mode corgi-stateline-mode
   "Toggle corgi-stateline-mode.
@@ -108,10 +100,15 @@
 When enabled, this mode will change the color of the mode line
 based on the current evil editing state."
   :init-value nil
-  :global t
-  (if (default-value 'corgi-stateline-mode)
+  (if corgi-stateline-mode
       (corgi-stateline/turn-on)
     (corgi-stateline/turn-off)))
+
+(define-globalized-minor-mode global-corgi-stateline-mode
+  corgi-stateline-mode
+  (lambda ()
+    (corgi-stateline-mode 1))
+  :group 'corgi)
 
 (provide 'corgi-stateline)
 

--- a/corgi-stateline/corgi-stateline.el
+++ b/corgi-stateline/corgi-stateline.el
@@ -56,7 +56,7 @@
   :type 'color
   :group 'corgi)
 
-(defvar corgi-stateline-remap-cookie nil
+(defvar-local corgi-stateline-remap-cookie nil
   "Cookie used to hold reference to face remapping.")
 
 (defun corgi-stateline/map-mode-line-face (fg bg)
@@ -86,7 +86,6 @@
                                       corgi-stateline-emacs-bg))
 
 (defun corgi-stateline/turn-on ()
-  (message "corgi-stateline adding hooks")
   (add-hook 'evil-normal-state-entry-hook #'corgi-stateline/enter-normal-state)
   (add-hook 'evil-motion-state-entry-hook #'corgi-stateline/enter-motion-state)
   (add-hook 'evil-insert-state-entry-hook #'corgi-stateline/enter-insert-state)
@@ -94,7 +93,6 @@
   (add-hook 'evil-emacs-state-entry-hook #'corgi-stateline/enter-emacs-state))
 
 (defun corgi-stateline/turn-off ()
-  (message "corgi-stateline Removing hooks")
   (remove-hook 'evil-normal-state-entry-hook #'corgi-stateline/enter-normal-state)
   (remove-hook 'evil-motion-state-entry-hook #'corgi-stateline/enter-motion-state)
   (remove-hook 'evil-insert-state-entry-hook #'corgi-stateline/enter-insert-state)
@@ -111,7 +109,6 @@ When enabled, this mode will change the color of the mode line
 based on the current evil editing state."
   :init-value nil
   :global t
-  :lighter " StLi"
   (if (default-value 'corgi-stateline-mode)
       (corgi-stateline/turn-on)
     (corgi-stateline/turn-off)))


### PR DESCRIPTION
- Change the face to mode-line rather than mode-line-active as that
  face only seems to be in Emacs 29 (development versions)
- Modified the code so that any previous face mapping is removed before
  adding a new face mapping
- Changed the package to define a new minor mode called corig-stateline-mode.
  This makes it easier for users to enable and disable. Also adds a minor mode
  indicator of 'StLi', which users can remove using diminish (or similar).

Probably need to tweak the default color settings. Might be good to start
by modifying the custom definitions for the colors so that it uses different
color sets for dark and light themes.


