### PR TITLE
Tweak completion configuration and associatged key bindings

### DIFF
--- a/corgi-bindings/corgi-keys.el
+++ b/corgi-bindings/corgi-keys.el
@@ -74,7 +74,7 @@
   ;; (")" "Up sexp" evil-cp-up-sexp)
 
   ("<M-up>" "Expand region" er/expand-region)
-  ("<M-down>" "Expand region" er/contract-region)
+  ("<M-down>" "Contract region" er/contract-region)
 
   ("gc" "Comment region" comment-region)
   ("gC" "Uncomment region" uncomment-region)

--- a/corgi-bindings/corgi-signals.el
+++ b/corgi-bindings/corgi-signals.el
@@ -5,7 +5,7 @@
 ;; the major (or sometimes minor) mode. This is how Corgi achieves consistency
 ;; in key bindings across languages.
 
-((default ( :command/execute execute-extended-command
+((default ( :command/execute counsel-M-x
 
             :file/open counsel-find-file
             :file/save save-buffer

--- a/corgi-editor/corgi-editor.el
+++ b/corgi-editor/corgi-editor.el
@@ -18,6 +18,8 @@
 (use-package ivy
   :defer 0.1
   :diminish
+  :init
+  (setq ivy-use-virtual-buffers t)
   :config
   (ivy-mode)
   (define-key ivy-minibuffer-map (kbd "C-j") #'ivy-next-line)
@@ -26,15 +28,17 @@
 (use-package counsel
   :after (ivy)
   :config
+  (counsel-mode)
   ;; This ensures that SPC f r (counsel-recentf, show recently opened files)
   ;; actually works
   (recentf-mode 1))
 
 ;; Make counsel-M-x show most recently used commands first
-(use-package smex)
+;;(use-package smex)
 
 (use-package swiper
-  :after (ivy))
+  :after (ivy)
+  :bind (("C-s" . swiper)))
 
 (use-package avy)
 

--- a/corgi-editor/corgi-editor.el
+++ b/corgi-editor/corgi-editor.el
@@ -33,8 +33,11 @@
   ;; actually works
   (recentf-mode 1))
 
-;; Make counsel-M-x show most recently used commands first
-;;(use-package smex)
+(use-package ivy-prescient
+  :after (ivy)
+  :config
+  (ivy-prescient-mode 1)
+  (prescient-persist-mode 1))
 
 (use-package swiper
   :after (ivy)


### PR DESCRIPTION
- Remove smex. Not really being used.
- Set M-x to use consoul-M-x
- Enable ivy virtual buffers to add recentf and bookmarks to switch-buffer
- Fix error in corgi-keys.el with "Expand Region" -> "Contract Region"

I found no difference in completion candidate ordering with and without smex being installed. Don't think we need that package.

M-x was not using counsel-M-x. This caused some subtle issues with Emacs built-in facilities to suggest shorter command names. With ivy running, you cannot use the suggested shorter names as ivy does not recognise them. When you use counsel-M-x, the short command name feature is disabled and prevents the misleading message, avoiding possible user confusion. 

Thought enabling ivy virtual buffers makes sense. Means that recentf and bookmarks are included in switch-to-buffer candidates. Means you can use switch-to-buffer (SPC b b) to also access recentf and bookmarks.

The corgi-keys.el file had the same doc string for both <M-up> and <M-down> "Expand region" -> changed <M-down> to "Contract region".
