### PR TITLE
Add bindings, bump CIDER, diminish Counsel

### DIFF
--- a/corgi-bindings/corgi-keys.el
+++ b/corgi-bindings/corgi-keys.el
@@ -87,8 +87,7 @@
     ("d" "Kill current buffer" kill-this-buffer)
     ("k" "Pick & kill" kill-buffer)
     ("l" "List buffers" list-buffers)
-    ("r" "Rename buffer" rename-buffer)
-    ("w" "Toggle read-only" :toggle/read-only))
+    ("r" "Rename buffer" rename-buffer))
 
    ("f" "File commands"
     ("f" "Find file" :file/open)
@@ -101,7 +100,10 @@
      ("k" "Open user-keys key bindings file" corgi/open-user-keys-file)
      ("s" "Open user-signals signals file" corgi/open-user-signals-file)
      ("K" "Open corgi-key key bindings file" corgi/open-keys-file)
-     ("S" "Open corgi-signals signals file" corgi/open-signals-file)))
+     ("S" "Open corgi-signals signals file" corgi/open-signals-file)
+     ("v" "Open Straight's default version file" corgi/open-straight-default-versions-file)
+     ("V" "Open Straight's version file installed by Corgi" corgi/open-straight-corgi-versions-file)
+     ("l" "Find library" find-library)))
 
    ("s" "Search commands"
     ("s" "Search in buffer" :buffer/incremental-search))
@@ -141,10 +143,13 @@
     ("d" "Delete window" delete-window))
 
    ("t" "Toggle modes"
-    ("a" "Toggle aggressive indent mode" aggressive-indent-mode)
-    ("l" "Toggle line numbers" display-line-numbers-mode)
-    ("q" "Toggle debug on quit" toggle-debug-on-quit)
-    ("e" "Toggle debug on error" toggle-debug-on-error))
+    ("a" "Toggle aggressive indent mode" :toggle/aggressive-indent)
+    ("l" "Toggle line numbers" :toggle/word-wrap)
+    ("q" "Toggle debug on quit" :toggle/debug-on-quit)
+    ("e" "Toggle debug on error" :toggle/debug-on-error)
+    ("w" "Toggle soft word-wrap" :toggle/soft-word-wrap)
+    ("W" "Toggle hard word-wrap" :toggle/hard-word-wrap)
+    ("r" "Toggle read-only" :toggle/read-only))
 
    ("x" "Text editing"
     ("t" "Transpose sexps" transpose-sexps)

--- a/corgi-bindings/corgi-signals.el
+++ b/corgi-bindings/corgi-signals.el
@@ -36,7 +36,13 @@
             :sexp/forward evil-cp-forward-sexp
             :sexp/backward evil-cp-backward-sexp
 
-            :toggle/read-only read-only-mode))
+            :toggle/read-only read-only-mode
+            :toggle/soft-word-wrap visual-line-mode
+            :toggle/hard-word-wrap auto-fill-mode
+            :toggle/line-numbers display-line-numbers-mode
+            :toggle/aggressive-indent aggressive-indent-mode
+            :toggle/debug-on-quit toggle-debug-on-quit
+            :toggle/debug-on-error toggle-debug-on-error))
 
  (prog-mode ( :format/tab-indent indent-for-tab-command
               :jump/definition xref-find-definitions

--- a/corgi-clojure/corgi-clojure.el
+++ b/corgi-clojure/corgi-clojure.el
@@ -1,7 +1,7 @@
 ;;; corgi-clojure.el --- Clojure configuration for Corgi -*- lexical-binding: t -*-
 ;;
 ;; Filename: corgi-clojure.el
-;; Package-Requires: ((use-package) (cider) (clj-ns-name) (clj-refactor) (clojure-mode))
+;; Package-Requires: ((use-package) (cider) (clj-ns-name) (clojure-mode))
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/corgi-commands/corgi-commands.el
+++ b/corgi-commands/corgi-commands.el
@@ -84,6 +84,16 @@ Will create one if it doesn't exist."
                  (expand-file-name "user-signals.el" user-emacs-directory)))
     (find-file (corgi/-locate-file 'user-signals))))
 
+(defun corgi/open-straight-corgi-versions-file ()
+  "Open the straight versions file for corgi packages"
+  (interactive)
+  (find-file (expand-file-name "straight/versions/corgi.el" user-emacs-directory)))
+
+(defun corgi/open-straight-default-versions-file ()
+  "Open the straight default versions file"
+  (interactive)
+  (find-file (expand-file-name "straight/versions/default.el" user-emacs-directory)))
+
 ;; Taking this out, see explanation in corgi-keys.el
 ;;
 ;; (defun corgi/emulate-tab ()

--- a/corgi-editor/corgi-editor.el
+++ b/corgi-editor/corgi-editor.el
@@ -25,6 +25,7 @@
 
 (use-package counsel
   :after (ivy)
+  :diminish
   :config
   ;; This ensures that SPC f r (counsel-recentf, show recently opened files)
   ;; actually works

--- a/corgi-versions.el
+++ b/corgi-versions.el
@@ -3,7 +3,7 @@
  ("aggressive-indent-mode" . "cb416faf61c46977c06cf9d99525b04dc109a33c")
  ("annalist.el" . "134fa3f0fb91a636a1c005c483516d4b64905a6d")
  ("avy" . "ba5f035be33693d1a136a5cbeedb24327f551a92")
- ("cider" . "3eff4f9b10f9b748d752ff70a68b0ffa3be06419")
+ ("cider" . "cfea755de682bb91dd59ef7e789d4d2bb170efe1")
  ("clj-ns-name" . "2a0898ba7888a07724dc40cdbba282371b921fd0")
  ("clj-refactor.el" . "f368c56c83843396b160440f472a661a3b639862")
  ("clojure-mode" . "b6f41d74904daa9312648f3a7bea7a72fd8e140b")


### PR DESCRIPTION
This upgrades CIDER because it had to accomodate a breaking change in Emacs master.

It removes the stated dependency on clj-refactor, we already removed the use-package earlier
but were still pulling it in.

It also adds a number of key bindings

- SPC f e v : open straight's default version file
- SPC f e V : open straight's corgi.el version file
- SPC f e l : Find (emacs lisp) library
- SPC t w : toggle soft word wrap (visual-line-mode)
- SPC t W : toggle hard word wrap (auto-fill-mode)
- SPC t r : toggle read only