### PR TITLE
Arne/tweaks 20220502

### DIFF
--- a/corgi-bindings/corgi-keys.el
+++ b/corgi-bindings/corgi-keys.el
@@ -144,12 +144,13 @@
 
    ("t" "Toggle modes"
     ("a" "Toggle aggressive indent mode" :toggle/aggressive-indent)
+    ("c" "Toggle completion" :toggle/completion)
+    ("e" "Toggle debug on error" :toggle/debug-on-error)
     ("l" "Toggle line numbers" :toggle/word-wrap)
     ("q" "Toggle debug on quit" :toggle/debug-on-quit)
-    ("e" "Toggle debug on error" :toggle/debug-on-error)
+    ("r" "Toggle read-only" :toggle/read-only)
     ("w" "Toggle soft word-wrap" :toggle/soft-word-wrap)
-    ("W" "Toggle hard word-wrap" :toggle/hard-word-wrap)
-    ("r" "Toggle read-only" :toggle/read-only))
+    ("W" "Toggle hard word-wrap" :toggle/hard-word-wrap))
 
    ("x" "Text editing"
     ("t" "Transpose sexps" transpose-sexps)

--- a/corgi-bindings/corgi-signals.el
+++ b/corgi-bindings/corgi-signals.el
@@ -42,7 +42,8 @@
             :toggle/line-numbers display-line-numbers-mode
             :toggle/aggressive-indent aggressive-indent-mode
             :toggle/debug-on-quit toggle-debug-on-quit
-            :toggle/debug-on-error toggle-debug-on-error))
+            :toggle/debug-on-error toggle-debug-on-error
+            :toggle/completion company-mode))
 
  (prog-mode ( :format/tab-indent indent-for-tab-command
               :jump/definition xref-find-definitions

--- a/corgi-clojure/corgi-clojure.el
+++ b/corgi-clojure/corgi-clojure.el
@@ -73,12 +73,14 @@
                  ((cider-maybe-intern type))))
           (repls (delete-dups (seq-mapcat #'cdr (or (sesman-current-sessions 'CIDER)
                                                     (when ensure
-                                                      (user-error "No linked CIDER sessions")))))))
+                                                      (user-error "No linked CIDER sessions"))))))
+          (bb-repl (get-buffer "*babashka-repl*")))
       (or (seq-filter (lambda (b)
                         (and (cider--match-repl-type type b)
-                             (not (equal b (get-buffer "*babashka-repl*")))))
+                             (not (equal b bb-repl))))
                       repls)
-          (list (get-buffer "*babashka-repl*")))))
+          (when bb-repl
+            (list bb-repl)))))
 
   (advice-add #'cider-repls :around #'corgi/around-cider-repls)
 

--- a/corgi-editor/corgi-editor.el
+++ b/corgi-editor/corgi-editor.el
@@ -69,6 +69,7 @@
 
 (use-package evil-collection
   :after (evil)
+  :diminish evil-collection-unimpaired-mode
   :config
   (evil-collection-init))
 

--- a/corgi-versions.el
+++ b/corgi-versions.el
@@ -8,7 +8,7 @@
  ("clj-refactor.el" . "f368c56c83843396b160440f472a661a3b639862")
  ("clojure-mode" . "b6f41d74904daa9312648f3a7bea7a72fd8e140b")
  ("company-mode" . "1005540b1cdf176cbcf893b2fa83d2075cbbe3ca")
- ("corkey" . "3818c6d3d797ecaebb84450ec529453c7482b9f1")
+ ("corkey" . "5c519e5068e2ec95d543b7afe9138a779b192a41")
  ("dash.el" . "7fd71338dce041b352f84e7939f6966f4d379459")
  ("diminish.el" . "6b7e837b0cf0129e9d7d6abae48093cf599bb9e8")
  ("dumb-jump" . "dbb915441a2b66f2fbb954ff5de2723c5a4771d4")


### PR DESCRIPTION
- Bump Corkey, this brings in two changes: follow symlinks when watching files, and preserve (point) when reading key/signal file buffers
- Add `SPC t c` as a toggle for completion (company-mode)
- Fix our "fall back to babashka repl" logic for the case there is no babashka repl
- Diminish `evil-collection-unimpaired-mode`, less noise in the modeline