### PR TITLE
Add flymake kondor

### DIFF
--- a/corgi-bindings/corgi-keys.el
+++ b/corgi-bindings/corgi-keys.el
@@ -109,6 +109,7 @@
     ("s" "Search in buffer" :buffer/incremental-search))
 
    ("p" "Project"
+    ("d" "Lint diagnostics" :project/diagnostics)
     ("f" "Find file" :project/open-file)
     ("p" "Switch project" :project/switch)
     ("k" "Kill buffers" :project/kill)
@@ -144,13 +145,12 @@
 
    ("t" "Toggle modes"
     ("a" "Toggle aggressive indent mode" :toggle/aggressive-indent)
-    ("c" "Toggle completion" :toggle/completion)
-    ("e" "Toggle debug on error" :toggle/debug-on-error)
     ("l" "Toggle line numbers" :toggle/word-wrap)
     ("q" "Toggle debug on quit" :toggle/debug-on-quit)
-    ("r" "Toggle read-only" :toggle/read-only)
+    ("e" "Toggle debug on error" :toggle/debug-on-error)
     ("w" "Toggle soft word-wrap" :toggle/soft-word-wrap)
-    ("W" "Toggle hard word-wrap" :toggle/hard-word-wrap))
+    ("W" "Toggle hard word-wrap" :toggle/hard-word-wrap)
+    ("r" "Toggle read-only" :toggle/read-only))
 
    ("x" "Text editing"
     ("t" "Transpose sexps" transpose-sexps)
@@ -211,6 +211,8 @@
     ("-" "Eval up to point" :eval/up-to-point))
 
    ("g" "Go places"
+    ("e" "Error next" :jump/next-error)
+    ("E" "Error previous" :jump/prev-error)
     ("g" "Go to definition" :jump/definition)
     ("b" "Go back" :jump/back)
     ("n" "Go to namespace" :jump/ns)

--- a/corgi-bindings/corgi-keys.el
+++ b/corgi-bindings/corgi-keys.el
@@ -145,12 +145,13 @@
 
    ("t" "Toggle modes"
     ("a" "Toggle aggressive indent mode" :toggle/aggressive-indent)
+    ("c" "Toggle completion" :toggle/completion)
+    ("e" "Toggle debug on error" :toggle/debug-on-error)
     ("l" "Toggle line numbers" :toggle/word-wrap)
     ("q" "Toggle debug on quit" :toggle/debug-on-quit)
-    ("e" "Toggle debug on error" :toggle/debug-on-error)
+    ("r" "Toggle read-only" :toggle/read-only)
     ("w" "Toggle soft word-wrap" :toggle/soft-word-wrap)
-    ("W" "Toggle hard word-wrap" :toggle/hard-word-wrap)
-    ("r" "Toggle read-only" :toggle/read-only))
+    ("W" "Toggle hard word-wrap" :toggle/hard-word-wrap))
 
    ("x" "Text editing"
     ("t" "Transpose sexps" transpose-sexps)
@@ -211,8 +212,6 @@
     ("-" "Eval up to point" :eval/up-to-point))
 
    ("g" "Go places"
-    ("e" "Error next" :jump/next-error)
-    ("E" "Error previous" :jump/prev-error)
     ("g" "Go to definition" :jump/definition)
     ("b" "Go back" :jump/back)
     ("n" "Go to namespace" :jump/ns)

--- a/corgi-bindings/corgi-signals.el
+++ b/corgi-bindings/corgi-signals.el
@@ -20,6 +20,7 @@
             :project/kill projectile-kill-buffers
             :project/incremental-search counsel-git-grep
             :project/switch-buffer projectile-switch-to-buffer
+            :project/diagnostics flymake-show-buffer-diagnostics
 
             :jump/identifier counsel-imenu
             :jump/character avy-goto-char
@@ -42,12 +43,13 @@
             :toggle/line-numbers display-line-numbers-mode
             :toggle/aggressive-indent aggressive-indent-mode
             :toggle/debug-on-quit toggle-debug-on-quit
-            :toggle/debug-on-error toggle-debug-on-error
-            :toggle/completion company-mode))
+            :toggle/debug-on-error toggle-debug-on-error))
 
  (prog-mode ( :format/tab-indent indent-for-tab-command
               :jump/definition xref-find-definitions
-              :jump/back xref-pop-marker-stack))
+              :jump/back xref-pop-marker-stack
+              :jump/next-error flymake-goto-next-error
+              :jump/prev-error flymake-goto-prev-error))
 
  (emacs-lisp-mode ( :eval/last-sexp eval-last-sexp
                     :eval/buffer eval-buffer

--- a/corgi-bindings/corgi-signals.el
+++ b/corgi-bindings/corgi-signals.el
@@ -43,13 +43,12 @@
             :toggle/line-numbers display-line-numbers-mode
             :toggle/aggressive-indent aggressive-indent-mode
             :toggle/debug-on-quit toggle-debug-on-quit
-            :toggle/debug-on-error toggle-debug-on-error))
+            :toggle/debug-on-error toggle-debug-on-error
+            :toggle/completion company-mode))
 
  (prog-mode ( :format/tab-indent indent-for-tab-command
               :jump/definition xref-find-definitions
-              :jump/back xref-pop-marker-stack
-              :jump/next-error flymake-goto-next-error
-              :jump/prev-error flymake-goto-prev-error))
+              :jump/back xref-pop-marker-stack))
 
  (emacs-lisp-mode ( :eval/last-sexp eval-last-sexp
                     :eval/buffer eval-buffer

--- a/corgi-clojure-kondo/corgi-clojure-kondo.el
+++ b/corgi-clojure-kondo/corgi-clojure-kondo.el
@@ -20,11 +20,13 @@
 ;;
 ;;; Code:
 
-(use-package flymake-kondor
-  :config
-  (add-hook 'clojure-mode-hook (lambda ()
-	                         (flymake-kondor-setup)
-                                 (flymake-mode +1))))
+(require 'flymake)
+
+(straight-use-package 'flymake-kondor)
+
+(add-hook 'clojure-mode-hook (lambda ()
+	                       (flymake-kondor-setup)
+                               (flymake-mode +1)))
 
 (provide 'corgi-clojure-kondo)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/corgi-clojure-kondo/corgi-clojure-kondo.el
+++ b/corgi-clojure-kondo/corgi-clojure-kondo.el
@@ -1,0 +1,37 @@
+;;; corgi-clojure-kondo.el --- clj-kondo configuration for Corgi -*- lexical-binding: t -*-
+;;
+;; Filename: corgi-clojure-kondo.el
+;; Package-Requires: ((flymake-kondor))
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Comentary
+;;
+;; To use this module, you need to install clj-kondo from
+;;   https://github.com/clj-kondo/clj-kondo and
+;; and enable this module in your init.el file e.g.
+;;
+;; (let ((straight-current-profile 'corgi))
+;;   ...
+;;
+;;   ;; Extensive setup for a good Clojure experience, including clojure-mode,
+;;   ;; CIDER, and a modeline indicator that shows which REPLs your evaluations go
+;;   ;; to.
+;;   ;; Also contains `corgi/cider-pprint-eval-register', bound to `,,', see
+;;   ;; `set-register' calls below.
+;;   (use-package corgi-clojure)
+;;   (use-package corgi-clojure-kondo)
+;;
+;;   ...
+;;   }
+;;
+;;; Code:
+
+(use-package flymake-kondor
+  :config
+  (add-hook 'clojure-mode-hook (lambda ()
+	                         (flymake-kondor-setup)
+                                 (flymake-mode +1))))
+
+(provide 'corgi-clojure-kondo)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; corgi-clojure-kondo.el ends here

--- a/corgi-clojure-kondo/corgi-clojure-kondo.el
+++ b/corgi-clojure-kondo/corgi-clojure-kondo.el
@@ -12,12 +12,6 @@
 ;;
 ;; (let ((straight-current-profile 'corgi))
 ;;   ...
-;;
-;;   ;; Extensive setup for a good Clojure experience, including clojure-mode,
-;;   ;; CIDER, and a modeline indicator that shows which REPLs your evaluations go
-;;   ;; to.
-;;   ;; Also contains `corgi/cider-pprint-eval-register', bound to `,,', see
-;;   ;; `set-register' calls below.
 ;;   (use-package corgi-clojure)
 ;;   (use-package corgi-clojure-kondo)
 ;;

--- a/corgi-clojure/corgi-clojure.el
+++ b/corgi-clojure/corgi-clojure.el
@@ -1,18 +1,13 @@
 ;;; corgi-clojure.el --- Clojure configuration for Corgi -*- lexical-binding: t -*-
 ;;
 ;; Filename: corgi-clojure.el
-;; Package-Requires: ((use-package) (cider) (clj-ns-name) (clojure-mode) (flymake-kondor))
+;; Package-Requires: ((use-package) (cider) (clj-ns-name) (clojure-mode))
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;;; Code:
 
 (require 'use-package)
-
-(use-package flymake-kondor
-  :config
-  (add-hook 'clojure-mode-hook (lambda ()
-	                         (flymake-kondor-setup))))
 
 (use-package clojure-mode
   :magic ("^#![^\n]*/\\(clj\\|clojure\\|bb\\|lumo\\)" . clojure-mode)

--- a/corgi-clojure/corgi-clojure.el
+++ b/corgi-clojure/corgi-clojure.el
@@ -28,7 +28,6 @@
 
         )
 
-
   ;; TODO: clean this up, submit to upstream where possible
   ;; More CIDER/clojure-mode stuff
   ;; - logical-sexp doesn't treat #_ correctly
@@ -74,12 +73,14 @@
                  ((cider-maybe-intern type))))
           (repls (delete-dups (seq-mapcat #'cdr (or (sesman-current-sessions 'CIDER)
                                                     (when ensure
-                                                      (user-error "No linked CIDER sessions")))))))
+                                                      (user-error "No linked CIDER sessions"))))))
+          (bb-repl (get-buffer "*babashka-repl*")))
       (or (seq-filter (lambda (b)
                         (and (cider--match-repl-type type b)
-                             (not (equal b (get-buffer "*babashka-repl*")))))
+                             (not (equal b bb-repl))))
                       repls)
-          (list (get-buffer "*babashka-repl*")))))
+          (when bb-repl
+            (list bb-repl)))))
 
   (advice-add #'cider-repls :around #'corgi/around-cider-repls)
 
@@ -130,7 +131,6 @@ creates a new one. Don't unnecessarily bother the user."
 
   (advice-add #'cider--choose-reusable-repl-buffer :around #'corgi/around-cider--choose-reusable-repl-buffer))
 
-
 ;; silence byte compiler
 (require 'clojure-mode)
 (require 'cider)
@@ -163,6 +163,7 @@ creates a new one. Don't unnecessarily bother the user."
   :config
   (clj-ns-name-install))
 
+(provide 'corgi-clojure)
 
 (defun corgi/cider-pprint-eval-register (register)
   "Evaluate a Clojure snippet stored in a register.
@@ -278,6 +279,5 @@ project or host."
       (when (eq 'clojure-mode major-mode)
         (corgi/enable-cider-connection-indicator-in-current-buffer)))))
 
-(provide 'corgi-clojure)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; corgi-clojure.el ends here

--- a/corgi-clojure/corgi-clojure.el
+++ b/corgi-clojure/corgi-clojure.el
@@ -1,13 +1,18 @@
 ;;; corgi-clojure.el --- Clojure configuration for Corgi -*- lexical-binding: t -*-
 ;;
 ;; Filename: corgi-clojure.el
-;; Package-Requires: ((use-package) (cider) (clj-ns-name) (clojure-mode))
+;; Package-Requires: ((use-package) (cider) (clj-ns-name) (clojure-mode) (flymake-kondor))
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;;; Code:
 
 (require 'use-package)
+
+(use-package flymake-kondor
+  :config
+  (add-hook 'clojure-mode-hook (lambda ()
+	                         (flymake-kondor-setup))))
 
 (use-package clojure-mode
   :magic ("^#![^\n]*/\\(clj\\|clojure\\|bb\\|lumo\\)" . clojure-mode)
@@ -27,6 +32,7 @@
         ;; nrepl-log-messages nil
 
         )
+
 
   ;; TODO: clean this up, submit to upstream where possible
   ;; More CIDER/clojure-mode stuff
@@ -73,14 +79,12 @@
                  ((cider-maybe-intern type))))
           (repls (delete-dups (seq-mapcat #'cdr (or (sesman-current-sessions 'CIDER)
                                                     (when ensure
-                                                      (user-error "No linked CIDER sessions"))))))
-          (bb-repl (get-buffer "*babashka-repl*")))
+                                                      (user-error "No linked CIDER sessions")))))))
       (or (seq-filter (lambda (b)
                         (and (cider--match-repl-type type b)
-                             (not (equal b bb-repl))))
+                             (not (equal b (get-buffer "*babashka-repl*")))))
                       repls)
-          (when bb-repl
-            (list bb-repl)))))
+          (list (get-buffer "*babashka-repl*")))))
 
   (advice-add #'cider-repls :around #'corgi/around-cider-repls)
 
@@ -131,6 +135,7 @@ creates a new one. Don't unnecessarily bother the user."
 
   (advice-add #'cider--choose-reusable-repl-buffer :around #'corgi/around-cider--choose-reusable-repl-buffer))
 
+
 ;; silence byte compiler
 (require 'clojure-mode)
 (require 'cider)
@@ -163,7 +168,6 @@ creates a new one. Don't unnecessarily bother the user."
   :config
   (clj-ns-name-install))
 
-(provide 'corgi-clojure)
 
 (defun corgi/cider-pprint-eval-register (register)
   "Evaluate a Clojure snippet stored in a register.
@@ -279,5 +283,6 @@ project or host."
       (when (eq 'clojure-mode major-mode)
         (corgi/enable-cider-connection-indicator-in-current-buffer)))))
 
+(provide 'corgi-clojure)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; corgi-clojure.el ends here

--- a/corgi-editor/corgi-editor.el
+++ b/corgi-editor/corgi-editor.el
@@ -1,7 +1,7 @@
 ;;; corgi-editor.el --- User interface configuration for Corgi -*- lexical-binding: t -*-
 ;;
 ;; Filename: corgi-editor.el
-;; Package-Requires: ((use-package) (aggressive-indent) (avy) (company) (counsel) (diminish) (dumb-jump) (evil) (evil-cleverparens) (evil-collection) (evil-surround) (expand-region) (goto-last-change) (ivy) (ivy-prescient) (projectile) (rainbow-delimiters) (smartparens) (smex) (string-edit) (swiper) (undo-fu) (which-key) (winum) (xclip))
+;; Package-Requires: ((use-package) (aggressive-indent) (avy) (company) (counsel) (diminish) (dumb-jump) (evil) (evil-cleverparens) (evil-collection) (evil-surround) (expand-region) (goto-last-change) (ivy) (ivy-prescient) (projectile) (rainbow-delimiters) (smartparens) (smex) (string-edit) (swiper) (undo-fu) (which-key) (winum) (xclip) (flymake))
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -48,6 +48,11 @@
 
 (use-package undo-fu)
 
+(use-package flymake
+  :config
+  (remove-hook 'flymake-diagnostic-functions #'flymake-proc-legacy-flymake)
+  (add-hook 'prog-mode-hook (lambda () (flymake-mode +1))))
+
 (use-package evil
   :init (setq evil-want-keybinding nil)
   :config
@@ -69,7 +74,6 @@
 
 (use-package evil-collection
   :after (evil)
-  :diminish evil-collection-unimpaired-mode
   :config
   (evil-collection-init))
 

--- a/corgi-editor/corgi-editor.el
+++ b/corgi-editor/corgi-editor.el
@@ -1,7 +1,7 @@
 ;;; corgi-editor.el --- User interface configuration for Corgi -*- lexical-binding: t -*-
 ;;
 ;; Filename: corgi-editor.el
-;; Package-Requires: ((use-package) (aggressive-indent) (avy) (company) (counsel) (diminish) (dumb-jump) (evil) (evil-cleverparens) (evil-collection) (evil-surround) (expand-region) (goto-last-change) (ivy) (ivy-prescient) (projectile) (rainbow-delimiters) (smartparens) (smex) (string-edit) (swiper) (undo-fu) (which-key) (winum) (xclip) (flymake))
+;; Package-Requires: ((use-package) (aggressive-indent) (avy) (company) (counsel) (diminish) (dumb-jump) (flymake) (evil) (evil-cleverparens) (evil-collection) (evil-surround) (expand-region) (goto-last-change) (ivy) (ivy-prescient) (projectile) (rainbow-delimiters) (smartparens) (smex) (string-edit) (swiper) (undo-fu) (which-key) (winum) (xclip))
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -46,12 +46,11 @@
 
 (use-package avy)
 
-(use-package undo-fu)
-
 (use-package flymake
   :config
-  (remove-hook 'flymake-diagnostic-functions #'flymake-proc-legacy-flymake)
-  (add-hook 'prog-mode-hook (lambda () (flymake-mode +1))))
+  (remove-hook 'flymake-diagnostic-functions #'flymake-proc-legacy-flymake))
+
+(use-package undo-fu)
 
 (use-package evil
   :init (setq evil-want-keybinding nil)
@@ -74,6 +73,7 @@
 
 (use-package evil-collection
   :after (evil)
+  :diminish evil-collection-unimpaired-mode
   :config
   (evil-collection-init))
 

--- a/corgi-packages.el
+++ b/corgi-packages.el
@@ -61,6 +61,7 @@
              corgi-emacs-lisp
              corgi-emacs
              corgi-clojure
+             corgi-clojure-kondo
              corgi-stateline))))
 
 (defun straight-recipes-corgi-packages-list ()


### PR DESCRIPTION
This PR adds flymake and flymake-kondor to add clj-kondo support to the clojure environment. It also adds 3 new key bindings -

SPC p d - display flymake diagnostics buffer
, g e - goto next flymake error/warning
, g E - goto previous flymake error/warning

You need to install clj-kondo for this mode to work. Will probably want to add some info to the manual, with a link to clj-kondo install instructions. 