### PR TITLE
Make `SPC b d` "Kill current buffer" more reliable

### DIFF
--- a/corgi-bindings/corgi-keys.el
+++ b/corgi-bindings/corgi-keys.el
@@ -84,7 +84,7 @@
   ("SPC" "Global leader key"
    ("b" "Buffer commands"
     ("b" "Switch buffer" ivy-switch-buffer)
-    ("d" "Kill current buffer" kill-this-buffer)
+    ("d" "Kill current buffer" kill-current-buffer)
     ("k" "Pick & kill" kill-buffer)
     ("l" "List buffers" list-buffers)
     ("r" "Rename buffer" rename-buffer))


### PR DESCRIPTION
Using Emacs 29.0.60 I noticed that `Kill current buffer` didn't work reliably any more:  does nothing, also doesn't produce errors.

Per the function's documentations, `kill-this-buffer` should only be invoked from the menu bar, whereas `kill-current-buffer` should be used instead.

https://github.com/emacs-mirror/emacs/blob/254c75fc2935e7edef079166d90b231278115a2f/lisp/simple.el#L6700-L6706

