### PR TITLE
Respect mode-specific initial state settings in evil

### DIFF
--- a/corgi-editor/corgi-editor.el
+++ b/corgi-editor/corgi-editor.el
@@ -166,7 +166,7 @@
   (unless (or (and (minibufferp) (not evil-want-minibuffer))
               (eq (current-buffer) corgi-editor--last-buffer))
     (setq corgi-editor--last-buffer (current-buffer))
-    (evil-normal-state)))
+    (evil-change-to-initial-state)))
 
 (if (boundp 'window-buffer-change-functions)
     ;; Emacs 27.1+ only


### PR DESCRIPTION
When using evil-set-initial-state, this state should be used instead of hard-coding normal-state. This is typical in e.g. term, vterm, eshell and similar modes, where starting in insert state is standard... Before this change corgi will force all those modes to normal state instead.