### PR TITLE
Only load emoji fonts when in GUI mode

### DIFF
--- a/corgi-defaults/corgi-defaults.el
+++ b/corgi-defaults/corgi-defaults.el
@@ -121,11 +121,13 @@
 ;; Stop asking about following symlinks to version controlled files
 (setq vc-follow-symlinks t)
 
-;; Configure common Emoji fonts, making it more likely that Emoji will work out of the box
-(set-fontset-font t 'symbol "Apple Color Emoji")
-(set-fontset-font t 'symbol "Noto Color Emoji" nil 'append)
-(set-fontset-font t 'symbol "Segoe UI Emoji" nil 'append)
-(set-fontset-font t 'symbol "Symbola" nil 'append)
+;; When Emacs is ran in GUI mode, configure common Emoji fonts, making it more
+;; likely that Emoji will work out of the box
+(when (display-graphic-p)
+  (set-fontset-font t 'symbol "Apple Color Emoji")
+  (set-fontset-font t 'symbol "Noto Color Emoji" nil 'append)
+  (set-fontset-font t 'symbol "Segoe UI Emoji" nil 'append)
+  (set-fontset-font t 'symbol "Symbola" nil 'append))
 
 (setq ring-bell-function 'ignore)
 


### PR DESCRIPTION
When Emacs is launched in a terminal `set-fontset-font` is nil and it makes loading Corgi fail.

From https://www.gnu.org/software/emacs/manual/html_node/elisp/Display-Feature-Testing.html,
`display-graphic-p` is a function that will return t if Emacs is in GUI mode. I put the emoji fonts loading in a `(when ...)` clause to fix the problem. :)