### PR TITLE
Make the cider-jack-in-babashka use the root of a project through projectile, if it exists

### DIFF
--- a/corgi-clojure/corgi-clojure.el
+++ b/corgi-clojure/corgi-clojure.el
@@ -225,7 +225,7 @@ specific project."
   (interactive)
   (when (get-buffer "*babashka-repl*")
     (kill-buffer "*babashka-repl*"))
-  (let ((project-dir (or project-dir user-emacs-directory)))
+  (let ((project-dir (or project-dir (projectile-project-root) user-emacs-directory)))
     (nrepl-start-server-process
      project-dir
      "bb --nrepl-server 0"


### PR DESCRIPTION
Hi again! As always, thanks for this neat project! This is a dirty edit so I can raise the issue I’m currently facing.

I am using babashka for some scripting involving file reading and writing. Since emacs + corgi have good support for anything Clojure they are my go-to for writing code. However `cider-jack-in-babashka` use the `user-emacs-directory` by default if `project-dir` is not provided, so any experimentation with files will end up there and not in the directory I want.

Am I missing something? Would it be possible to jack-in automatically in a project folder? I’m not sure how I would do it manually either.

But I would like to get the cake and eat it too. With a quick change now the `project-dir` variable takes the path of `projectile-project-root` if there is any before relenting to `user-emacs-directory`. I understand that `cider-jack-in-babashka` is supposed to not be tied to any specific project, but this seemed the most easy and straightforward way to circumvent my problem.

Thanks in advance for your time and consideration :)