### PR TITLE
cli-parameters is no longer used as global options

### DIFF
--- a/corgi-clojure/corgi-clojure.el
+++ b/corgi-clojure/corgi-clojure.el
@@ -160,10 +160,10 @@ creates a new one. Don't unnecessarily bother the user."
 ;; Most annoying JVM "feature" of all time
 ;; https://docs.cider.mx/cider/troubleshooting.html#empty-java-stacktraces
 (defun corgi/around-cider-jack-in-global-options (command project-type)
-  (if (eq 'clojure-cli project-type)
-      (concat cider-clojure-cli-parameters
-              " -J-XX:-OmitStackTraceInFastThrow")
-    (funcall command project-type)))
+  (let ((opts (funcall command project-type)))
+    (if (eq 'clojure-cli project-type)
+        (concat opts " -J-XX:-OmitStackTraceInFastThrow")
+      opts)))
 
 (advice-add #'cider-jack-in-global-options :around #'corgi/around-cider-jack-in-global-options)
 ;; (use-package clj-refactor


### PR DESCRIPTION
Fixes issues where if `cider-clojure-cli-parameters` is null then jack-in
fails with an error:

Symbol’s value as variable is void: cider-clojure-cli-parameters