### PR TITLE
Gnarly match-state mutable state bug

### DIFF
--- a/corgi-clojure/corgi-clojure.el
+++ b/corgi-clojure/corgi-clojure.el
@@ -202,9 +202,10 @@ evaluated, like `(println \"{{buffer-file-name}}\")'.
   (let ((reg (replace-regexp-in-string
               "{{\\([^}]+\\)}}"
               (lambda (s)
-                (eval
-                 (read
-                  (match-string 1 s))))
+		(save-match-data
+		  (eval
+                   (read
+                    (match-string 1 s)))))
               (get-register register))))
     (cond
      ((string-match-p "^#_cljs" reg)


### PR DESCRIPTION
Since a very long time I've wanted to do this `,,t` to run all tests in the current buffer I am in.

That should be easy right? We have the entire power of elisp at our fingertips. Quickly found that the fn I need is `(cider-current-ns)` and voila:

```elisp
(set-register ?t "#_clj (do (require 'clojure.test) (clojure.test/run-tests '{{(cider-current-ns)}}))")
```

Unfortunately this breaks only for some functions, `cider-current-ns` being one of them. WEIRD RIGHT?!?! Using edebug was fruitless. 

This was the output I was getting:

```elisp
;; => (do (require 'clojure.test) (clojure.test/run-tests 'ox.amazing-prog(cider-current-ns)}}))
```

After weeks of frustration, I finally sat down today and decided to fix this anyhow. 

Turns out `match-string` is stateful!! It depends on the last search/regex emacs made.

So if the code to be eval'd in the register does any kind of search, this function breaks.

`save-match-data` makes sure the code outside of eval still has the match-state preserved!

I cant finally `,,t` in peace!