### PR TITLE
Fix compatibility with latest CIDER's cider-repls API

### DIFF
--- a/corgi-clojure/corgi-clojure.el
+++ b/corgi-clojure/corgi-clojure.el
@@ -68,7 +68,7 @@
   ;; REPLs by using sesman-current-sessions (plural) instead of
   ;; sesman-current-session. It also falls back to the babashka repl if no repls
   ;; are connected/linked, so we can always eval.
-  (defun corgi/around-cider-repls (_command &optional type ensure)
+  (defun corgi/around-cider-repls (_command &optional type ensure required-ops)
     (let ((type (cond
                  ((listp type)
                   (mapcar #'cider-maybe-intern type))
@@ -79,7 +79,12 @@
           (bb-repl (get-buffer "*babashka-repl*")))
       (or (seq-filter (lambda (b)
                         (and (cider--match-repl-type type b)
-                             (not (equal b bb-repl))))
+                             (not (equal b bb-repl))
+                             ;; Filter by required-ops if specified
+                             (or (null required-ops)
+                                 (seq-every-p (lambda (op)
+                                                (nrepl-op-supported-p op b))
+                                              required-ops))))
                       repls)
           (when bb-repl
             (list bb-repl)))))


### PR DESCRIPTION
## Summary

Fixes compatibility issue with the latest version of CIDER where `cider-repls` API signature changed to include a third optional parameter.

## Problem

CIDER updated `cider-repls` function signature from:
```elisp
(defun cider-repls (&optional type ensure)
```

to:
```elisp
(defun cider-repls (&optional type ensure required-ops)
```

This caused `corgi/around-cider-repls` advice to fail with:
```
Debugger entered--Lisp error: (wrong-number-of-arguments (1 . 3) 4)
  corgi/around-cider-repls(#<subr cider-repls> cljs nil nil)
```

## Solution

- Updated `corgi/around-cider-repls` to accept the new `required-ops` parameter
- Added filtering logic to support CIDER's operation-based REPL filtering
- Maintains backward compatibility when `required-ops` is nil

## Testing

- Verified no byte-compilation errors
- Signature now matches CIDER's current API
- Filtering logic follows CIDER's implementation pattern
- Tested with actual CIDER evaluation and confirmed fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)